### PR TITLE
Adding that = this snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ function ${1:methodName} (${2:arguments}) {
 })();
 ```
 
+### [vt] that = this
+
+```javascript
+var that = this${1:;}
+```
 
 ### [me] module.exports 
 

--- a/vanilla.that.sublime-snippet
+++ b/vanilla.that.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+    <content><![CDATA[
+var that = this${1:;}
+]]></content>
+    <tabTrigger>vt</tabTrigger>
+    <scope>source.js</scope>
+</snippet>


### PR DESCRIPTION
I very often come across the need to write `var that = this` to start off a block of variable initialization. Thought it would be helpful to others. 
