### PR TITLE
adding trailing commas to snippets

### DIFF
--- a/bdd.describe.sublime-snippet
+++ b/bdd.describe.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[describe('${1:description}', function() {
 	${0:// body...}
-})
+});
 ]]></content>
     <tabTrigger>desc</tabTrigger>
     <scope>source.js</scope>

--- a/bdd.ita.sublime-snippet
+++ b/bdd.ita.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[it('${1:description}', function(done) {
 	${0:// body...}
-})
+});
 ]]></content>
     <tabTrigger>ita</tabTrigger>
     <scope>source.js</scope>

--- a/bdd.its.sublime-snippet
+++ b/bdd.its.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[it('${1:description}', function() {
 	${0:// body...}
-})
+});
 ]]></content>
     <tabTrigger>its</tabTrigger>
     <scope>source.js</scope>

--- a/vanilla.console_dir.sublime-snippet
+++ b/vanilla.console_dir.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-console.dir(${1:obj})${0}
+console.dir(${1:obj});${0}
 ]]></content>
     <tabTrigger>cd</tabTrigger>
     <scope>source.js</scope>

--- a/vanilla.console_error.sublime-snippet
+++ b/vanilla.console_error.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-console.error(${1:error})${0}
+console.error(${1:error});${0}
 ]]></content>
     <tabTrigger>ce</tabTrigger>
     <scope>source.js</scope>

--- a/vanilla.console_log.sublime-snippet
+++ b/vanilla.console_log.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-console.log(${1:msg})${0}
+console.log(${1:msg});${0}
 ]]></content>
     <tabTrigger>cl</tabTrigger>
     <scope>source.js</scope>

--- a/vanilla.console_log_util_inspect.sublime-snippet
+++ b/vanilla.console_log_util_inspect.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-console.log(require('util').inspect(${1:obj}, true, ${2:10}, true))${0}
+console.log(require('util').inspect(${1:obj}, true, ${2:10}, true));${0}
 ]]></content>
     <tabTrigger>cli</tabTrigger>
     <scope>source.js</scope>

--- a/vanilla.console_trace.sublime-snippet
+++ b/vanilla.console_trace.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-console.trace(${1:error})${0}
+console.trace(${1:error});${0}
 ]]></content>
     <tabTrigger>ct</tabTrigger>
     <scope>source.js</scope>

--- a/vanilla.module_exports.sublime-snippet
+++ b/vanilla.module_exports.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-module.exports = ${1}
+module.exports = ${1};
 ]]></content>
     <tabTrigger>me</tabTrigger>
     <scope>source.js</scope>

--- a/vanilla.object_keys_foreach.sublime-snippet
+++ b/vanilla.object_keys_foreach.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[Object.keys(${1:obj}).forEach(function(key) {
 	${0:// body...}
-})
+});
 ]]></content>
     <tabTrigger>okfe</tabTrigger>
     <scope>source.js</scope>

--- a/vanilla.process_exit.sublime-snippet
+++ b/vanilla.process_exit.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-process.exit()
+process.exit();
 ]]></content>
     <tabTrigger>pe</tabTrigger>
     <scope>source.js</scope>

--- a/vanilla.require.sublime-snippet
+++ b/vanilla.require.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-require('${1:package}')${0}
+require('${1:package}');${0}
 ]]></content>
     <tabTrigger>req</tabTrigger>
     <scope>source.js</scope>

--- a/vanilla.setinterval.sublime-snippet
+++ b/vanilla.setinterval.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[setInterval(function() {
 	${2:// body...}
-}, ${1:millis})
+}, ${1:millis});
 ]]></content>
     <tabTrigger>sti</tabTrigger>
     <scope>source.js</scope>

--- a/vanilla.settimeout.sublime-snippet
+++ b/vanilla.settimeout.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[setTimeout(function() {
 	${2:// body...}
-}, ${1:millis})
+}, ${1:millis});
 ]]></content>
     <tabTrigger>sto</tabTrigger>
     <scope>source.js</scope>

--- a/vanilla.use_strict.sublime-snippet
+++ b/vanilla.use_strict.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-'use strict'
+'use strict';
 ]]></content>
     <tabTrigger>us</tabTrigger>
     <scope>source.js</scope>


### PR DESCRIPTION
Without the semicolon ST2 won't offer variable suggestions within the line when also using the jslint package. Which is annoying for the `console.*` snippets. Semi colon use is more in favor now than previously, and they only hurt when they're not around. Happy to discuss.
